### PR TITLE
introduce has_root run_condition

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -5,6 +5,8 @@ use bevy::{prelude::*, utils::EntityHashMap};
 use measure::LayoutMeasure;
 use taffy::{Size, TaffyTree};
 
+use crate::has_root;
+
 #[derive(Component, Deref, DerefMut, Default, Debug, Clone)]
 pub struct WoodpeckerStyle(taffy::Style);
 
@@ -139,8 +141,10 @@ impl WoodpeckerStyle {
 pub struct WoodpeckerLayoutPlugin;
 impl Plugin for WoodpeckerLayoutPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<UiLayout>()
-            .add_systems(Update, system::run.after(crate::runner::system));
+        app.init_resource::<UiLayout>().add_systems(
+            Update,
+            system::run.after(crate::runner::system).run_if(has_root()),
+        );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,8 @@ impl Plugin for WoodpeckerUIPlugin {
                     runner::system,
                     focus::CurrentFocus::click_focus,
                     keyboard_input::runner,
-                ),
+                )
+                    .run_if(has_root()),
             )
             .add_systems(
                 Update,
@@ -84,6 +85,10 @@ impl Plugin for WoodpeckerUIPlugin {
             )
             .add_systems(Startup, startup);
     }
+}
+
+fn has_root() -> impl Condition<(), ()> {
+    IntoSystem::into_system(|context: Res<WoodpeckerContext>| context.root_widget.is_some())
 }
 
 fn startup(mut commands: Commands) {


### PR DESCRIPTION
When using woodpecker in a game that uses states, woodpecker will crash looking for the root node. One solution could be to not run woodpecker if there is no root, which seems reasonable. This commit introduces that restriction for relevant systems.

for example in a file like this, using bevy_asset_loader for assets.

```rust
use bevy::prelude::*;
use woodpecker_ui::prelude::*;

use crate::{
    assets::{FontAssets, FontVelloAssets},
    AppState,
};

pub struct MainMenuPlugin;

impl Plugin for MainMenuPlugin {
    fn build(&self, app: &mut App) {
        app.add_systems(
            OnEnter(AppState::MainMenu),
            spawn_main_menu,
        );
    }
}

fn spawn_main_menu(
    mut commands: Commands,
    mut ui_context: ResMut<WoodpeckerContext>,
    fonts: Res<FontVelloAssets>,
) {
    let root = commands
        .spawn((
            WoodpeckerAppBundle {
                ..Default::default()
            },
            WidgetRender::Text {
                font: fonts.outfit_extra_bold.clone(),
                size: 40.0,
                color: Color::WHITE,
                alignment: VelloTextAlignment::TopLeft,
                content: "Hello World! I am Woodpecker UI!"
                    .into(),
                word_wrap: false,
            },
        ))
        .id();
    ui_context.set_root_widget(root);
}
```