### PR TITLE
Render overlapping font glyphs as filled instead of cutout

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -223,7 +223,7 @@ impl WidgetRender {
                             color.blue as f64,
                             color.alpha as f64,
                         )))
-                        .draw(vello::peniko::Fill::EvenOdd, line.glyphs.into_iter());
+                        .draw(vello::peniko::Fill::NonZero, line.glyphs.into_iter());
                     prev_line_width += line.width as f64;
                 }
             }


### PR DESCRIPTION
I don't know if this change is strictly correct, but it doesn't break "Poppins-Regular" and it fixes the "Outfit" variations I was using.

Here is the `EvenOdd` behavior:

![screenshot-2024-07-19-at-21 40 01@2x](https://github.com/user-attachments/assets/6f6d887b-f3af-453d-a18c-a49321e5991e)

and these are both the `NonZero` behavior.

![screenshot-2024-07-19-at-21 28 59@2x](https://github.com/user-attachments/assets/bd9dc888-577e-49f1-8aec-d86e65da5f0b)
![screenshot-2024-07-19-at-21 36 18@2x](https://github.com/user-attachments/assets/ab2be7b7-b765-482b-917f-c87f2758ab66)

---

bevy_vello switched from a kurbo stroke to EvenOdd [about four months ago](https://github.com/linebender/bevy_vello/commit/cca085c313bd10c298aff8db4dcf3bd198219f36#diff-4efd2c351b8414fce877168c416f7d0436cc62756a997f45e53998476465db14R117)

peniko::Fill is only the "interior" though, so it seems right.

> Describes the rule that determines the interior portion of a shape.

---

and here's a link to [Outfit](https://fonts.google.com/specimen/Outfit) if you want to download it to test.