### PR TITLE
WidgetVisibility

### DIFF
--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -1,0 +1,368 @@
+use bevy::{color::palettes::tailwind::RED_400, prelude::*};
+use bevy_mod_picking::{
+    events::{Click, Pointer},
+    prelude::On,
+    DefaultPickingPlugins,
+};
+use woodpecker_ui::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(WoodpeckerUIPlugin::default())
+        .add_plugins(DefaultPickingPlugins)
+        .register_widget::<MyWidget>()
+        .add_systems(Startup, startup)
+        .run();
+}
+
+fn startup(mut commands: Commands, mut ui_context: ResMut<WoodpeckerContext>) {
+    commands.spawn(Camera2dBundle::default());
+
+    let root = commands
+        .spawn(WoodpeckerAppBundle {
+            children: WidgetChildren::default().with_child::<MyWidget>(MyWidgetBundle {
+                styles: WoodpeckerStyle {
+                    display: WidgetDisplay::Flex,
+                    flex_direction: WidgetFlexDirection::Column,
+                    ..default()
+                },
+                my_widget: MyWidget,
+                ..default()
+            }),
+            ..default()
+        })
+        .id();
+    ui_context.set_root_widget(root);
+}
+
+#[derive(Component, Clone, Default, Debug, Copy, PartialEq)]
+pub struct MyWidgetState {
+    text: WidgetVisibility,
+    image: WidgetVisibility,
+    quad: WidgetVisibility,
+    svg: WidgetVisibility,
+    nine_patch: WidgetVisibility,
+    layer: WidgetVisibility,
+}
+
+#[derive(Widget, Component, Clone, Default, Reflect, Copy, PartialEq)]
+#[auto_update(render)]
+#[props(MyWidget)]
+#[state(MyWidgetState)]
+struct MyWidget;
+
+#[derive(Bundle, Default, Clone)]
+struct MyWidgetBundle {
+    my_widget: MyWidget,
+    styles: WoodpeckerStyle,
+    children: WidgetChildren,
+}
+
+fn render(
+    mut commands: Commands,
+    mut hooks: ResMut<HookHelper>,
+    current_widget: Res<CurrentWidget>,
+    mut query: Query<(&MyWidget, &mut WidgetChildren)>,
+    state_query: Query<&mut MyWidgetState>,
+    asset_server: ResMut<AssetServer>,
+) {
+    let Ok((_, mut widget_children)) = query.get_mut(**current_widget) else {
+        return;
+    };
+
+    let state_entity = hooks.use_state(
+        &mut commands,
+        *current_widget,
+        MyWidgetState {
+            text: WidgetVisibility::Visible,
+            image: WidgetVisibility::Visible,
+            quad: WidgetVisibility::Visible,
+            svg: WidgetVisibility::Visible,
+            nine_patch: WidgetVisibility::Visible,
+            layer: WidgetVisibility::Visible,
+        },
+    );
+
+    let Ok(state) = state_query.get(state_entity) else {
+        return;
+    };
+
+    let buttons = WidgetChildren::default()
+        .with_child::<WButton>((
+            WButtonBundle {
+                children: WidgetChildren::default().with_child::<Element>((
+                    ElementBundle {
+                        styles: WoodpeckerStyle {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        ..default()
+                    },
+                    WidgetRender::Text {
+                        content: "Text".into(),
+                        word_wrap: false,
+                    },
+                )),
+                ..default()
+            },
+            On::<Pointer<Click>>::run(move |mut query: Query<&mut MyWidgetState>| {
+                let Ok(mut input) = query.get_mut(state_entity) else {
+                    return;
+                };
+                input.text = match input.text {
+                    WidgetVisibility::Visible => WidgetVisibility::Hidden,
+                    WidgetVisibility::Hidden => WidgetVisibility::Visible,
+                };
+            }),
+        ))
+        .with_child::<WButton>((
+            WButtonBundle {
+                children: WidgetChildren::default().with_child::<Element>((
+                    ElementBundle {
+                        styles: WoodpeckerStyle {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        ..default()
+                    },
+                    WidgetRender::Text {
+                        content: "Image".into(),
+                        word_wrap: false,
+                    },
+                )),
+                ..default()
+            },
+            On::<Pointer<Click>>::run(move |mut query: Query<&mut MyWidgetState>| {
+                let Ok(mut input) = query.get_mut(state_entity) else {
+                    return;
+                };
+                input.image = match input.image {
+                    WidgetVisibility::Visible => WidgetVisibility::Hidden,
+                    WidgetVisibility::Hidden => WidgetVisibility::Visible,
+                };
+            }),
+        ))
+        .with_child::<WButton>((
+            WButtonBundle {
+                children: WidgetChildren::default().with_child::<Element>((
+                    ElementBundle {
+                        styles: WoodpeckerStyle {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        ..default()
+                    },
+                    WidgetRender::Text {
+                        content: "Quad".into(),
+                        word_wrap: false,
+                    },
+                )),
+                ..default()
+            },
+            On::<Pointer<Click>>::run(move |mut query: Query<&mut MyWidgetState>| {
+                let Ok(mut input) = query.get_mut(state_entity) else {
+                    return;
+                };
+                input.quad = match input.quad {
+                    WidgetVisibility::Visible => WidgetVisibility::Hidden,
+                    WidgetVisibility::Hidden => WidgetVisibility::Visible,
+                };
+            }),
+        ))
+        .with_child::<WButton>((
+            WButtonBundle {
+                children: WidgetChildren::default().with_child::<Element>((
+                    ElementBundle {
+                        styles: WoodpeckerStyle {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        ..default()
+                    },
+                    WidgetRender::Text {
+                        content: "SVG".into(),
+                        word_wrap: false,
+                    },
+                )),
+                ..default()
+            },
+            On::<Pointer<Click>>::run(move |mut query: Query<&mut MyWidgetState>| {
+                let Ok(mut input) = query.get_mut(state_entity) else {
+                    return;
+                };
+                input.svg = match input.svg {
+                    WidgetVisibility::Visible => WidgetVisibility::Hidden,
+                    WidgetVisibility::Hidden => WidgetVisibility::Visible,
+                };
+            }),
+        ))
+        .with_child::<WButton>((
+            WButtonBundle {
+                children: WidgetChildren::default().with_child::<Element>((
+                    ElementBundle {
+                        styles: WoodpeckerStyle {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        ..default()
+                    },
+                    WidgetRender::Text {
+                        content: "nine_patch".into(),
+                        word_wrap: false,
+                    },
+                )),
+                ..default()
+            },
+            On::<Pointer<Click>>::run(move |mut query: Query<&mut MyWidgetState>| {
+                let Ok(mut input) = query.get_mut(state_entity) else {
+                    return;
+                };
+                input.nine_patch = match input.nine_patch {
+                    WidgetVisibility::Visible => WidgetVisibility::Hidden,
+                    WidgetVisibility::Hidden => WidgetVisibility::Visible,
+                };
+            }),
+        ))
+        .with_child::<WButton>((
+            WButtonBundle {
+                children: WidgetChildren::default().with_child::<Element>((
+                    ElementBundle {
+                        styles: WoodpeckerStyle {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        ..default()
+                    },
+                    WidgetRender::Text {
+                        content: "layer".into(),
+                        word_wrap: false,
+                    },
+                )),
+                ..default()
+            },
+            On::<Pointer<Click>>::run(move |mut query: Query<&mut MyWidgetState>| {
+                let Ok(mut input) = query.get_mut(state_entity) else {
+                    return;
+                };
+                input.layer = match input.layer {
+                    WidgetVisibility::Visible => WidgetVisibility::Hidden,
+                    WidgetVisibility::Hidden => WidgetVisibility::Visible,
+                };
+            }),
+        ));
+
+    widget_children
+        .add::<Element>((ElementBundle {
+            styles: WoodpeckerStyle {
+                margin: Edge::all(10.0),
+                display: WidgetDisplay::Flex,
+                gap: (Units::Pixels(5.), Units::Pixels(5.)),
+                width: Units::Pixels(100.),
+                ..default()
+            },
+            children: buttons,
+            ..default()
+        },))
+        .add::<Element>((
+            ElementBundle {
+                styles: WoodpeckerStyle {
+                    visibility: state.text,
+                    font_size: 50.0,
+                    color: Srgba::RED.into(),
+                    margin: Edge::all(10.0),
+                    ..default()
+                },
+                ..default()
+            },
+            WidgetRender::Text {
+                content: "Hello World! I am Woodpecker UI!".into(),
+                word_wrap: false,
+            },
+        ))
+        .add::<Element>((
+            ElementBundle {
+                styles: WoodpeckerStyle {
+                    visibility: state.image,
+                    height: Units::Pixels(100.),
+                    ..default()
+                },
+                ..default()
+            },
+            WidgetRender::Image {
+                handle: asset_server.load("woodpecker.jpg"),
+            },
+        ))
+        .add::<Element>((
+            ElementBundle {
+                styles: WoodpeckerStyle {
+                    visibility: state.quad,
+                    height: Units::Pixels(100.),
+                    background_color: RED_400.into(),
+                    ..default()
+                },
+                ..default()
+            },
+            WidgetRender::Quad,
+        ))
+        .add::<Element>((
+            ElementBundle {
+                styles: WoodpeckerStyle {
+                    visibility: state.svg,
+                    height: Units::Pixels(100.),
+                    ..default()
+                },
+                ..default()
+            },
+            WidgetRender::Svg {
+                handle: asset_server.load("woodpecker_svg/woodpecker.svg"),
+                color: Some(Srgba::GREEN.into()),
+            },
+        ))
+        .add::<Element>((
+            ElementBundle {
+                styles: WoodpeckerStyle {
+                    visibility: state.nine_patch,
+                    width: 100.0.into(),
+                    height: 200.0.into(),
+                    ..default()
+                },
+                ..default()
+            },
+            WidgetRender::NinePatch {
+                handle: asset_server.load("slice.png"),
+                scale_mode: ImageScaleMode::Sliced(TextureSlicer {
+                    border: BorderRect::square(135.),
+                    center_scale_mode: SliceScaleMode::Stretch,
+                    ..default()
+                }),
+            },
+        ))
+        .add::<Element>((
+            ElementBundle {
+                styles: WoodpeckerStyle {
+                    visibility: state.layer,
+                    width: 100.0.into(),
+                    height: 50.0.into(),
+                    ..default()
+                },
+                children: WidgetChildren::default().with_child::<Element>((
+                    ElementBundle {
+                        styles: WoodpeckerStyle {
+                            height: Units::Pixels(100.),
+                            ..default()
+                        },
+                        ..default()
+                    },
+                    WidgetRender::Svg {
+                        handle: asset_server.load("woodpecker_svg/woodpecker.svg"),
+                        color: Some(Srgba::RED.into()),
+                    },
+                )),
+                ..default()
+            },
+            WidgetRender::Layer,
+        ));
+
+    widget_children.apply(current_widget.as_parent());
+}

--- a/src/styles/layout.rs
+++ b/src/styles/layout.rs
@@ -31,6 +31,17 @@ impl From<WidgetDisplay> for taffy::Display {
     }
 }
 
+/// Visibility shows or hides an element without changing the layout of a document.
+#[derive(Default, Reflect, Copy, Clone, PartialEq, Eq, Debug)]
+pub enum WidgetVisibility {
+    /// The element box is visible.
+    #[default]
+    Visible,
+    /// The element box is invisible (not drawn), but still affects layout as normal. Descendants of the element will be visible if they
+    /// have visibility set to visible. The element cannot receive focus (such as when navigating through tab indexes).
+    Hidden,
+}
+
 /// How children overflowing their container should affect layout
 ///
 /// In CSS the primary effect of this property is to control whether contents of a parent container that overflow that container should

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -42,6 +42,8 @@ pub struct WoodpeckerStyle {
     ///
     /// The default values depends on on which feature flags are enabled. The order of precedence is: Flex, Grid, Block, None.
     pub display: WidgetDisplay,
+    /// Show or hide an element without changing layout
+    pub visibility: WidgetVisibility,
     /// How children overflowing their container should affect layout
     ///
     /// In CSS the primary effect of this property is to control whether contents of a parent container that overflow that container should
@@ -212,6 +214,7 @@ impl WoodpeckerStyle {
             bottom: Units::Pixels(0.0),
         },
         display: WidgetDisplay::Flex,
+        visibility: WidgetVisibility::Visible,
         overflow: WidgetOverflow::Visible,
         position: WidgetPosition::Relative,
         left: Units::Auto,


### PR DESCRIPTION
Implement Visibility for Elements.

Visibility should remove interactivity and visuals but keep the Element's space in the layout in the same way it would be if fully rendered.

> [!IMPORTANT]  
> After working on this, I'm not sure this is any different than "just" setting the opacity to 0. Woodpecker doesn't have control over what users set Pickable on, so Visibility can't prevent interactivity without adding a Pickable with specific settings. This feels a lot like future accessibility work that this PR does not cover.
>
> caveat: setting opacity doesn't currently work on Images.

This commit doesn't implement Visibility for children below a Hidden parent, although Layers provide part of this functionality since they control the opacity of their children.

https://github.com/user-attachments/assets/f4576ac5-8cdc-48d4-9b9b-0bdf1bd182cf

